### PR TITLE
Add a JSM test to email forwarding

### DIFF
--- a/lambda_/email-forwarder/main.py
+++ b/lambda_/email-forwarder/main.py
@@ -67,6 +67,10 @@ forward_mapping = {
         "system_email": "tech@gccc.zendesk.com",
         "reply_from": "tech@gc3.security.gov.uk",
     },
+    "tech-jsm": {
+        "system_email": "tech@gc3-external.atlassian.net",
+        "reply_from": "tech-jsm@gc3.security.gov.uk",
+    },
     "ollie": {
         "system_email": "oliver.chalk@digital.cabinet-office.gov.uk",
         "reply_from": "ollie@gc3.security.gov.uk",


### PR DESCRIPTION
Adds an entry for `tech-jsm[at]..` to forward to Jira Service Management for testing